### PR TITLE
Fix example for on release action

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ jobs:
   publishOnMasterRelease:
     name: Publish release to Netlify
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' && github.event.action == 'created' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'release' && github.event.action == 'created'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v1


### PR DESCRIPTION
## Description

* Releases don't have `github.ref == 'refs/heads/master'` so the example action will never run if used