### PR TITLE
feat: add outputs to get the preview-url and preview-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ There are 4 required inputs for the action
 
 See the [action.yml](./action.yml) for other action inputs and their descriptions
 
+## Outputs
+
+### `preview-url`
+
+The url of deployment preview.
+
+### `preview-name`
+
+The name of deployment name.
+
 ## Usage
 
 Here are some ideas of how to configure this action in different workflows...

--- a/action.yml
+++ b/action.yml
@@ -66,3 +66,9 @@ inputs:
   message:
     description: "A short message to associate with the deploy (Note: setting this will override the default deploy message of `<type>: <title> [short_sha]`)"
     required: false
+
+outputs:
+  preview-url:
+    description: 'deployment preview URL'
+  preview-name:
+    description: 'deployment preview name'

--- a/src/main.ts
+++ b/src/main.ts
@@ -84,6 +84,8 @@ async function run(): Promise<void> {
         const deployment = await netlifyClient.deploy(siteId, siteDir, { configPath, draft, fnDir, message });
 
         deploy = deployment.deploy;
+        core.setOutput('preview-name', deploy.name);
+        core.setOutput('preview-url', getDeployUrl(draft, deploy));
       } catch (error) {
         process.stderr.write('netlifyClient.deploy() failed\n');
         process.stderr.write(`${JSON.stringify(error, null, 2)}\n`);


### PR DESCRIPTION
## Description

Basically I want to get the preview-url generated by netlify to run some e2e tests and Lighthouse suite to that URL.

Vercel deployment action already does this.
